### PR TITLE
Remove onTriage from the newly created Mintel specific dashboard as w…

### DIFF
--- a/config/config.ru
+++ b/config/config.ru
@@ -2,6 +2,7 @@ require 'dashing'
 
 configure do
   set :auth_token, 'YOUR_AUTH_TOKEN'
+  set :default_dashboard, 'opsgenie_alerts'
 
   helpers do
     def protected!

--- a/dashboards/opsgenie_alerts_mintel.erb
+++ b/dashboards/opsgenie_alerts_mintel.erb
@@ -1,0 +1,35 @@
+
+<div class="gridster">
+  <ul>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_p1" data-title="P1" data-cool="0" data-warm="0"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_open" data-title="Open" data-cool="0" data-warm="2"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_unseen" data-title="Not Seen" data-cool="0" data-warm="2"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_unack"  data-title="Not Ackd" data-cool="0" data-warm="2"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_p2" data-title="P2" data-cool="0" data-warm="2"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="Hotness" data-id="opsgenie_p3" data-title="P3" data-cool="2" data-warm="5"></div>
+  </li>
+
+  <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+    <div data-view="List" data-id="opsgenie_on_call" data-title="OnCall"></div>
+  </li>
+
+ </ul>
+
+</div>

--- a/jobs/opsgenie_alerts.rb
+++ b/jobs/opsgenie_alerts.rb
@@ -89,6 +89,8 @@ SCHEDULER.every '60s', :first_in => 0 do |job|
   p1_alerts     = 0
   p2_alerts     = 0
   p3_alerts     = 0
+  p4_alerts     = 0
+  p5_alerts     = 0
 
   if alerts
     alerts.each do |a|
@@ -115,6 +117,12 @@ SCHEDULER.every '60s', :first_in => 0 do |job|
       if a["priority"] == "P3"
         p3_alerts +=1
       end
+      if a["priority"] == "P4"
+        p4_alerts +=1
+      end
+      if a["priority"] == "P5"
+        p5_alerts +=1
+      end
     end
     end
 
@@ -124,4 +132,6 @@ SCHEDULER.every '60s', :first_in => 0 do |job|
   send_event('opsgenie_p1', value: p1_alerts)
   send_event('opsgenie_p2', value: p2_alerts)
   send_event('opsgenie_p3', value: p3_alerts)
+  send_event('opsgenie_p4', value: p4_alerts)
+  send_event('opsgenie_p5', value: p5_alerts)
 end


### PR DESCRIPTION
Remove onTriage from the newly created Mintel specific dashboard as we don't use the distinction any more.  Set the default dashboard to the existing one and capture all P1-5 alert counts so people can use the individually.